### PR TITLE
feat: add deployment to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,13 @@
 name: Release to OSSRH Sonatype
 on:
   push:
-    branches:
-      - develop
-      - master
+    tags:
+      - 'v*'
 
 jobs:
   gradle-wrapper-validation:
     name: Validate Gradle Wrapper
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
     steps:
       - name: Fetch sources
         uses: actions/checkout@v2
@@ -17,11 +15,10 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-  release-snapshot:
-    name: Release snapshot version
+  release:
+    name: Release to Sonatype OSSRH
     needs: gradle-wrapper-validation
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
     steps:
       - name: Fetch sources
         uses: actions/checkout@v2
@@ -45,13 +42,14 @@ jobs:
           echo "${{secrets.SIGNING_SECRET_KEY_RING_CONTENT}}" | base64 -d > ringkey.gpg
           gpg --quiet --batch --yes --decrypt --passphrase="${{secrets.SECRET_PASSPHRASE}}" --output secring.gpg ringkey.gpg
 
-      - name: Release Deployment to Snapshot Repository
+      - name: Release to OSSRH Staging repository
         run: |
           ./gradlew publish -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} \
                             -Psigning.password=${{secrets.SIGNING_PASSWORD}} \
                             -Psigning.secretKeyRingFile=secring.gpg \
                             -PossrhUsername=${{secrets.OSSRH_USERNAME}} \
-                            -PossrhPassword=${{secrets.OSSRH_PASSWORD}}
+                            -PossrhPassword=${{secrets.OSSRH_PASSWORD}} \
+                            -Prelease
 
       - name: Post Setting GPG key
         run: rm -rf *.gpg

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ plugins {
 
 group = "io.snyk.code.sdk"
 archivesBaseName = "snyk-code-client"
-version = "2.1.6-SNAPSHOT"
-ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+version = "2.1.6"
 
 repositories {
     mavenCentral()
@@ -66,9 +65,7 @@ integTest.dependsOn test
 publishing {
     repositories {
         maven {
-            def releaseRepo = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotRepo = "https://oss.sonatype.org/content/repositories/snapshots/"
-            url = isReleaseVersion ? releaseRepo : snapshotRepo
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
                 username = project.hasProperty("ossrhUsername") ? ossrhUsername : "Unknown user"
                 password = project.hasProperty("ossrhPassword") ? ossrhPassword : "Unknown password"
@@ -109,5 +106,5 @@ signing {
     sign publishing.publications.maven
 }
 tasks.withType(Sign) {
-    onlyIf { isReleaseVersion }
+    onlyIf { project.hasProperty("release") }
 }


### PR DESCRIPTION
This PR changes flow how we deploy to Sonatype OSSRH:
- improvements/bugs will be developed in feature branches (`feat/`, `fix/` etc)
- project will be deployed to Sonatype OSSRH by tagging in `master` branch
- `publishToMavenLocal` task can be used for local testing/development (without signing)