### PR TITLE
fix: add missing name attribute for generated pom.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ publishing {
             pom {
                 description = "Snyk Code Public API package in Java"
                 url = "https://github.com/snyk/snyk-code-client"
+                name = "Snyk Code API Client"
                 developers {
                     developer {
                         id = "ArtsiomCh"


### PR DESCRIPTION
This PR fixes validation on OSSRH side with missing `name` attribute for generated pom.xml